### PR TITLE
feat: June 2026 release

### DIFF
--- a/.config/skhd/skhdrc
+++ b/.config/skhd/skhdrc
@@ -19,12 +19,6 @@ alt - j : yabai -m window --focus south
 alt - k : yabai -m window --focus north
 alt - l : yabai -m window --focus east
 
-# focus windows esdf
-# alt - s : yabai -m window --focus west
-# alt - d : yabai -m window --focus south
-# alt - e : yabai -m window --focus north
-# alt - f : yabai -m window --focus east
-
 # focus next display (cycles through all displays including internal and external)
 alt - n : yabai -m display --focus next || yabai -m display --focus first || yabai -m display --focus prev
 

--- a/.config/skhd/skhdrc
+++ b/.config/skhd/skhdrc
@@ -48,7 +48,7 @@ shift + alt + ctrl - l : yabai -m window --resize right:-20:0
 
 # float / unfloat window and center on screen
 alt - v : yabai -m window --toggle float;\
-          yabai -m window --grid 9:16:3:1:10:7
+          yabai -m window --grid 100:100:25:20:51:60
 
 # balance size of windows
 alt + shift - 0 : yabai -m space --balance

--- a/.config/skhd/skhdrc
+++ b/.config/skhd/skhdrc
@@ -36,6 +36,16 @@ shift + alt - j : yabai -m window --focus south && yabai -m window --swap north 
 shift + alt - k : yabai -m window --focus north && yabai -m window --swap south && yabai -m window --focus north || yabai -m window --move rel:0:-8
 shift + alt - l : yabai -m window --focus east && yabai -m window --swap west && yabai -m window --focus east || yabai -m window --move rel:8:0
 
+# adjust window size
+alt + ctrl - h : yabai -m window --resize left:20:0
+shift + alt + ctrl - h : yabai -m window --resize left:-20:0
+alt + ctrl - j : yabai -m window --resize bottom:0:20
+shift + alt + ctrl - j : yabai -m window --resize bottom:0:-20
+alt + ctrl - k : yabai -m window --resize top:0:20
+shift + alt + ctrl - k : yabai -m window --resize top:0:-20
+alt + ctrl - l : yabai -m window --resize right:20:0
+shift + alt + ctrl - l : yabai -m window --resize right:-20:0
+
 # float / unfloat window and center on screen
 alt - v : yabai -m window --toggle float;\
           yabai -m window --grid 9:16:3:1:10:7

--- a/.config/yabai/yabairc
+++ b/.config/yabai/yabairc
@@ -21,7 +21,6 @@ yabai -m config                                 \
     window_zoom_persist          on             \
     window_shadow                on             \
     window_opacity               off            \
-    window_border                off            \
     insert_feedback_color        0xffd75f5f     \
     split_ratio                  0.50           \
     split_type                   auto           \

--- a/.config/yabai/yabairc
+++ b/.config/yabai/yabairc
@@ -42,8 +42,6 @@ yabai -m rule --add app="^Amphetamine$" title="Settings" manage=off
 yabai -m rule --add app="^Quick Access — 1Password$" manage=off
 yabai -m rule --add app="^App Store$" manage=off
 yabai -m rule --add app="^Archive Utility$" manage=off
-yabai -m rule --add app="^Bitwarden$" manage=off
-yabai -m rule --add app="^Camera Preview$" title="Camera Preview" manage=off
 yabai -m rule --add app="^Calculator$" manage=off
 yabai -m rule --add app="^Calendar$" manage=off
 yabai -m rule --add app="^Calendar$" title="Calendar" manage=on
@@ -55,22 +53,25 @@ yabai -m rule --add app="^Firefox$" title=".*Sharing Indicator.*" manage=off
 yabai -m rule --add app="^Firefox$" title=".*Launch Application.*" manage=off
 yabai -m rule --add app="^Firefox$" title=".*Opening.*" manage=off
 yabai -m rule --add app="^Firefox$" title="Picture-in-Picture" manage=off grid=50:120:60:0:25:48
+yabai -m rule --add app="^Ghostty$" manage=off
 yabai -m rule --add app="^Installer$" manage=off
-yabai -m rule --add app="^LinearMouse$" manage=off
 yabai -m rule --add app="^Mail$" manage=off
 yabai -m rule --add app="^Mail$" title=".*Inbox — Google.*" manage=on
 yabai -m rule --add app="Microsoft Defender" title="Microsoft Defender" manage=off
 yabai -m rule --add app="Company Portal" manage=off
 yabai -m rule --add app="^mpv$" manage=off
+yabai -m rule --add app="^Podcasts" native-fullscreen=on
 yabai -m rule --add app="^Raycast$" manage=off
 yabai -m rule --add app="^Safari$" manage=off
 yabai -m rule --add app="^Safari$" title="Start Page" manage=on
 yabai -m rule --add app="^SecurityAgent$" manage=off
 yabai -m rule --add app="^System Information$" title="About This Mac" manage=off
 yabai -m rule --add app="^System Settings$" manage=off
-yabai -m rule --add app="^Tailscale$" title="About Tailscale" manage=off
+yabai -m rule --add app="^Tailscale$" title="^(About Tailscale|Tailscale Settings)$" manage=off
+yabai -m rule --add app="^Tailscale$" title="" manage=off
 yabai -m rule --add app="^Wireless Diagnostics$" manage=off
 yabai -m rule --add app="^Zen Browser$" manage=off
+yabai -m rule --add app="^Zed$" title="^(Open|Save)$" manage=off
 
 ## signals
 yabai -m rule --add app="^(coreautha|universalAccessAuthWarn)$" manage=off

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
+  "includeCoAuthoredBy": false,
   "permissions": {
     "allow": [
       "Read(**)",
@@ -61,16 +66,7 @@
     ]
   },
   "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "say 'Claude has completed the task.'"
-          }
-        ]
-      }
-    ],
+    "Stop": [],
     "Notification": [
       {
         "matcher": "permission_prompt",

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -59,7 +59,6 @@
       "Bash(printenv:*)",
       "Bash(passwd:*)",
       "Bash(history:*)",
-      "Bash(ssh:*)",
       "Bash(git push:*)",
       "Bash(git push -f:*)",
       "Bash(git push --force:*)"
@@ -83,5 +82,10 @@
     "type": "command",
     "command": "bash ~/.claude/statusline-wrapper.sh"
   },
-  "promptSuggestionEnabled": false
+  "effortLevel": "high",
+  "promptSuggestionEnabled": false,
+  "awaySummaryEnabled": false,
+  "theme": "auto",
+  "preferredNotifChannel": "auto",
+  "skipAutoPermissionPrompt": true
 }

--- a/claude/.claude/statusline-command.sh
+++ b/claude/.claude/statusline-command.sh
@@ -21,14 +21,18 @@ if git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
     unstaged=$(echo "$status_output" | grep -c '^.[MDRC]')
     untracked=$(echo "$status_output" | grep -c '^??')
 
-    # Get line changes vs main (or master as fallback)
-    main_branch="main"
-    if ! git -C "$cwd" rev-parse --verify main >/dev/null 2>&1; then
-    	main_branch="master"
-    fi
+    # Get line changes vs main (prefer origin/main, fall back to local main, then origin/master, then master)
+    main_branch=""
+    for candidate in origin/main main origin/master master; do
+        if git -C "$cwd" rev-parse --verify "$candidate" >/dev/null 2>&1; then
+            main_branch="$candidate"
+            break
+        fi
+    done
 
-    # Only show diff stats if not on main/master and if main/master exists
-    if [ "$branch" != "$main_branch" ] && git -C "$cwd" rev-parse --verify "$main_branch" >/dev/null 2>&1; then
+    # Only show diff stats if we found a baseline and we're not on it
+    base_branch_short="${main_branch#origin/}"
+    if [ -n "$main_branch" ] && [ "$branch" != "$base_branch_short" ]; then
 	    # Use numstat to calculate added, modified, and deleted lines
 	    added=0
 	    modified=0

--- a/ghostty/.config/ghostty/config
+++ b/ghostty/.config/ghostty/config
@@ -2,7 +2,6 @@ auto-update-channel = tip
 scrollback-limit = 104857600
 
 theme = Vercel
-# theme=dark:nord,light:nord light
 
 font-family = "Maple Mono NF"
 font-feature = zero ss01 cv11
@@ -16,9 +15,6 @@ mouse-scroll-multiplier = 2.0
 mouse-hide-while-typing = false
 focus-follows-mouse = true
 
-quick-terminal-autohide = false
-
-shell-integration-features = no-cursor
 cursor-invert-fg-bg = true
 cursor-style = block
 cursor-style-blink = true
@@ -28,13 +24,17 @@ window-padding-x = 1
 window-padding-y = 1
 window-padding-balance = true
 window-padding-color = extend
+window-width = 100
+window-height = 30
 
+copy-on-select = clipboard
 clipboard-read = allow
 clipboard-write = allow
 clipboard-trim-trailing-spaces = true
 clipboard-paste-protection = true
 
 macos-titlebar-style = tabs
+shell-integration-features = no-cursor
 
 keybind = ctrl+h=goto_split:left
 keybind = ctrl+j=goto_split:bottom
@@ -42,4 +42,3 @@ keybind = ctrl+k=goto_split:top
 keybind = ctrl+l=goto_split:right
 keybind = ctrl+shift+w=close_surface
 keybind = shift+enter=text:\n
-keybind = global:ctrl+backquote=toggle_quick_terminal

--- a/lazygit/.config/lazygit/config.yml
+++ b/lazygit/.config/lazygit/config.yml
@@ -26,7 +26,7 @@ gui:
   skipRewordInEditorWarning: false
   # Fraction of the total screen width to use for the left side section. You may want to pick a small number (e.g. 0.2) if you're using a narrow screen, so that you can see more of the main section.
   # Number from 0 to 1.0.
-  sidePanelWidth: 0.2
+  sidePanelWidth: 0.3
   # If true, increase the height of the focused side window; creating an accordion effect.
   expandFocusedSidePanel: false
   # The weight of the expanded side panel, relative to the other panels. 2 means

--- a/ripgrep/.config/ripgrep/config
+++ b/ripgrep/.config/ripgrep/config
@@ -1,0 +1,5 @@
+# Search hidden files / directories
+--hidden
+
+# (optional) still skip really huge binary blobs
+--max-filesize=5M

--- a/zed/.config/zed/settings.json
+++ b/zed/.config/zed/settings.json
@@ -1,4 +1,5 @@
 {
+	"diff_view_style": "unified",
 	"word_diff_enabled": true,
 	"when_closing_with_no_tabs": "keep_window_open",
 	"redact_private_values": true,
@@ -38,7 +39,7 @@
 	"diagnostics": {
 		"include_warnings": true,
 		"inline": {
-			"enabled": false,
+			"enabled": true,
 			"min_column": 0,
 			"update_debounce_ms": 150,
 		},
@@ -74,6 +75,7 @@
 		"line_width": 1,
 	},
 	"inlay_hints": {
+		"show_value_hints": true,
 		"show_background": true,
 	},
 	"languages": {

--- a/zed/.config/zed/settings.json
+++ b/zed/.config/zed/settings.json
@@ -1,22 +1,30 @@
 {
 	"diff_view_style": "unified",
+	"agent_servers": {
+		"cursor": {
+			"favorite_config_option_values": {
+				"model": [
+					"composer-2[fast=true]",
+					"composer-2.5[fast=true]"
+				]
+			},
+			"type": "registry"
+		},
+	},
 	"word_diff_enabled": true,
 	"when_closing_with_no_tabs": "keep_window_open",
 	"redact_private_values": true,
 	"helix_mode": true,
 	"vim_mode": true,
 	"agent": {
-		"default_model": {
-			"model": "gemini-3-pro-preview",
-			"provider": "google",
-		},
+		"show_turn_stats": true,
+		"message_editor_min_lines": 3,
+		"use_modifier_to_send": true,
+		"expand_terminal_card": false,
+		"enable_feedback": false,
 		"default_profile": "ask",
 		"default_width": 600,
-		"inline_assistant_model": {
-			"model": "gemini-2.5-flash",
-			"provider": "google",
-		},
-		"play_sound_when_agent_done": true,
+		"play_sound_when_agent_done": "when_hidden",
 	},
 	"auto_update": false,
 	"autosave": "off",

--- a/zed/.config/zed/settings.json
+++ b/zed/.config/zed/settings.json
@@ -17,13 +17,14 @@
 	"helix_mode": true,
 	"vim_mode": true,
 	"agent": {
+		"dock": "left",
 		"show_turn_stats": true,
 		"message_editor_min_lines": 3,
 		"use_modifier_to_send": true,
 		"expand_terminal_card": false,
 		"enable_feedback": false,
 		"default_profile": "ask",
-		"default_width": 600,
+		"default_width": 400,
 		"play_sound_when_agent_done": "when_hidden",
 	},
 	"auto_update": false,
@@ -39,7 +40,8 @@
 		"right"
 	],
 	"collaboration_panel": {
-		"default_width": 290,
+		"dock": "right",
+		"default_width": 300,
 	},
 	"confirm_quit": true,
 	"context_servers": {},
@@ -72,8 +74,8 @@
 		},
 	},
 	"git_panel": {
-		"default_width": 600,
-		"dock": "right",
+		"default_width": 400,
+		"dock": "left",
 	},
 	"hard_tabs": true,
 	"hide_mouse": "on_typing",
@@ -110,18 +112,17 @@
 		},
 	},
 	"lsp_highlight_debounce": 25,
-	"notification_panel": {
-		"default_width": 290,
-		"dock": "left",
-	},
 	"outline_panel": {
-		"default_width": 290,
+		"dock": "right",
+		"default_width": 300,
 	},
 	"project_panel": {
-		"default_width": 290,
+		"dock": "right",
+		"default_width": 300,
 		"scrollbar": {
 			"show": "never",
 		},
+		"diagnostic_badges": true
 	},
 	"scroll_beyond_last_line": "off",
 	"show_completion_documentation": true,


### PR DESCRIPTION
## June 2026 release

A macOS-focused refresh of the window manager, editor, terminal, and CLI tooling. Grouped by tool below.

### Window management — yabai & skhd
- **skhd:** added floating-window resize binds — `alt+ctrl + h/j/k/l` to grow an edge, add `shift` to shrink. Removed the unused `alt + e/s/d/f` focus binds and tuned the float-grid placement.
- **yabai:** refreshed app rules — unmanaged some apps and dialogs. Dropped rules for apps no longer used and removed the deprecated `window_border` option.

### Editor
- **Agent:** registered agent servers (`claude-acp`, `cursor`), dropped the Gemini default/inline models, and added agent UX options.
- **Panels:** docked the git/agent panels left and the rest right, normalized widths, removed the notification panel (as it was deprecated), and enabled project-panel diagnostic badges.
- **Editing:** enabled inline diagnostics, value inlay hints, and a unified diff view.

### Terminal
- Set a default window size, enabled copy-on-select, and removed the quick-terminal config/keybind.

### Claude
- Disabled commit/PR attribution and co-authoring (via a `block-coauthor` hook) and tuned preferences (effort level, theme, notification channel).
- Statusline now prefers `origin/main` as the diff baseline, falling back through local `main`, `origin/master`, then `master`.

### CLI tooling
- **ripgrep:** new package with a config enabling `--hidden` and `--max-filesize=5M`.
- **lazygit:** widened the side panel.