### PR TITLE
feat: August 2026 release

### DIFF
--- a/.config/skhd/skhdrc
+++ b/.config/skhd/skhdrc
@@ -47,8 +47,14 @@ alt + ctrl - l : yabai -m window --resize right:20:0
 shift + alt + ctrl - l : yabai -m window --resize right:-20:0
 
 # float / unfloat window and center on screen
-alt - v : yabai -m window --toggle float;\
-          yabai -m window --grid 100:100:25:20:51:60
+alt - v : if yabai -m query --windows --window | jq -e '.app == "Ghostty" and ."is-floating" == false' >/dev/null; then \
+              yabai -m window --toggle float; \
+              yabai -m window --resize abs:755:549; \
+              yabai -m window --move abs:$(yabai -m query --displays --display | jq '.frame.x + ((.frame.w - 755) / 2)'):$(yabai -m query --displays --display | jq '.frame.y + ((.frame.h - 549) / 2)'); \
+          else \
+              yabai -m window --toggle float; \
+              yabai -m window --grid 100:100:25:20:51:60; \
+          fi
 
 # balance size of windows
 alt + shift - 0 : yabai -m space --balance

--- a/.config/skhd/skhdrc
+++ b/.config/skhd/skhdrc
@@ -59,20 +59,6 @@ alt - e : yabai -m window --toggle split
 # rotate tree
 alt - r : yabai -m space --rotate 90
 
-# toggle window padding for the space
-alt - p : yabai -m config top_padding 16;\
-          yabai -m config right_padding 16;\
-          yabai -m config bottom_padding 16;\
-          yabai -m config left_padding 16;\
-          yabai -m space --toggle padding;\
-          yabai -m space --toggle gap
-
-# toggle large/small window padding for the space
-shift + alt - p : yabai -m config top_padding 128;\
-                  yabai -m config right_padding 128;\
-                  yabai -m config bottom_padding 128;\
-                  yabai -m config left_padding 128;
-
 # toggle window zoom fullscreen
 alt - f : yabai -m window --toggle zoom-fullscreen
 

--- a/.config/yabai/yabairc
+++ b/.config/yabai/yabairc
@@ -50,7 +50,7 @@ yabai -m rule --add app="^DiskImages UI Agent$" manage=off
 yabai -m rule --add app="^Finder$" manage=off
 yabai -m rule --add app="^Firefox$" title!=".+" manage=off
 yabai -m rule --add app="^Firefox$" title=".*(Sharing Indicator|Launch Application|Opening).*" manage=off
-yabai -m rule --add app="^Firefox$" title="Picture-in-Picture" manage=off grid=50:120:60:0:25:48
+yabai -m rule --add app="^Firefox$" title="Picture-in-Picture" manage=off
 yabai -m rule --add app="^Ghostty$" manage=off
 yabai -m rule --add app="^Installer$" manage=off
 yabai -m rule --add app="^Mail$" manage=off

--- a/claude/.claude/statusline-command.sh
+++ b/claude/.claude/statusline-command.sh
@@ -6,17 +6,34 @@ input=$(cat)
 # Extract values from JSON (without jq)
 cwd=$(echo "$input" | sed -n 's/.*"current_dir":"\([^"]*\)".*/\1/p')
 
+# Extract model name, clean up: drop claude- prefix and date suffix, truncate
+model=$(echo "$input" | jq -r '
+  if .model | type == "object" then .model.id // .model.name // "claude"
+  elif .model | type == "string" then .model
+  else "claude"
+  end
+' 2>/dev/null)
+[ -z "$model" ] || [ "$model" = "null" ] && model="claude"
+model=$(echo "$model" | sed 's/claude-//' | sed 's/-[0-9]\{8\}$//' | cut -c1-10)
+
+# Model block: Claude orange
+model_bg='\033[48;2;217;119;87m'
+
+# Branch block background: light blue when git tree is clean, gold when dirty
+git_bg='\033[48;5;75m'
+
 # Git information (skip optional locks for performance)
 if git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
 	# Get just the repo name (the git root directory basename)
     git_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)
     repo_name=$(basename "$git_root")
 
-    # Get branch
+    # Get branch (the wrapper truncates it only if the line overflows)
     branch=$(git -C "$cwd" --no-optional-locks rev-parse --abbrev-ref HEAD 2>/dev/null)
 
     # Get staged/unstaged/untracked counts in one call
     status_output=$(git -C "$cwd" --no-optional-locks status --porcelain 2>/dev/null)
+    [ -n "$status_output" ] && git_bg='\033[48;2;239;199;116m'
     staged=$(echo "$status_output" | grep -c '^[MADRC]')
     unstaged=$(echo "$status_output" | grep -c '^.[MDRC]')
     untracked=$(echo "$status_output" | grep -c '^??')
@@ -33,6 +50,10 @@ if git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
     # Only show diff stats if we found a baseline and we're not on it
     base_branch_short="${main_branch#origin/}"
     if [ -n "$main_branch" ] && [ "$branch" != "$base_branch_short" ]; then
+	    # Diff from the merge-base to the working tree so staged and
+	    # unstaged changes count, not just commits
+	    merge_base=$(git -C "$cwd" --no-optional-locks merge-base "$main_branch" HEAD 2>/dev/null)
+
 	    # Use numstat to calculate added, modified, and deleted lines
 	    added=0
 	    modified=0
@@ -50,15 +71,20 @@ if git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
 	                modified=$((modified + add))
 	            fi
 	        fi
-	    done <<< "$(git -C "$cwd" --no-optional-locks diff --numstat "$main_branch"...HEAD 2>/dev/null)"
+	    done <<< "$(git -C "$cwd" --no-optional-locks diff --numstat "${merge_base:-$main_branch}" 2>/dev/null)"
 
-	    printf '\033[01;36m%s\033[0m | \033[01;34m%s\033[0m \033[0;32m+%s\033[0m/\033[38;5;208m~%s\033[0m/\033[0;31m-%s\033[0m' \
-	    "$repo_name" "$branch" "$added" "$modified" "$deleted"
+	    # Colored blocks: model on orange, repo on blue, branch on blue (clean) / gold (dirty)
+	    # Output protocol for the wrapper:
+	    #   line 1: block template, @TRUNC@ marks the truncatable value
+	    #   line 2: the raw truncatable value (branch or path)
+	    #   line 3 (optional): diff stats to right-align at line end
+	    printf "$model_bg"'\033[1;30m %s \033[0m@5H@\033[44m\033[30m %s \033[0m'"$git_bg"'\033[30m @TRUNC@ \033[0m\n%s\n\033[0;32m+%s\033[0m/\033[38;5;208m~%s\033[0m/\033[0;31m-%s\033[0m' \
+	    "$model" "$repo_name" "$branch" "$added" "$modified" "$deleted"
     else
-	    printf '\033[01;36m%s\033[0m | \033[01;34m%s\033[0m' \
-	    "$repo_name" "$branch"
+	    printf "$model_bg"'\033[1;30m %s \033[0m@5H@\033[44m\033[30m %s \033[0m'"$git_bg"'\033[30m @TRUNC@ \033[0m\n%s' \
+	    "$model" "$repo_name" "$branch"
     fi
 else
-	# Not a git repo
-	printf '\033[01;36m%s\033[00m' "$cwd"
+	# Not a git repo: model block, then cwd on blue block
+	printf "$model_bg"'\033[1;30m %s \033[0m@5H@\033[44m\033[30m @TRUNC@ \033[0m\n%s' "$model" "$cwd"
 fi

--- a/claude/.claude/statusline-wrapper.sh
+++ b/claude/.claude/statusline-wrapper.sh
@@ -3,8 +3,14 @@
 # Read JSON input once
 input=$(cat)
 
-# Get git info from existing script
-git_info=$(echo "$input" | bash ~/.claude/statusline-command.sh)
+# Get git info from existing script.
+# Line 1: block template (@TRUNC@ = truncatable value slot).
+# Line 2: raw truncatable value (branch or path).
+# Line 3 (optional): diff stats to right-align.
+git_output=$(echo "$input" | bash ~/.claude/statusline-command.sh)
+line_tpl=$(printf '%s' "$git_output" | sed -n 1p)
+trunc_val=$(printf '%s' "$git_output" | sed -n 2p)
+diff_info=$(printf '%s' "$git_output" | sed -n 3p)
 
 # Get context window info
 used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // 0')
@@ -24,6 +30,43 @@ format_k() {
     fi
 }
 
+# --- Line 2 helpers (style from pchalasani/claude-code-tools statusline) ---
+RESET=$'\033[0m'
+BLINK=$'\033[5m'
+DIM=$'\033[38;5;244m'
+LABEL=$'\033[38;5;250m'
+FG_WHITE=$'\033[97m'
+
+# Format a unix-epoch reset time as a compact countdown, e.g. "2h13m", "4d6h"
+fmt_reset() {
+    local target=$1 now delta d h m
+    now=$(date +%s)
+    delta=$((target - now))
+    [ "$delta" -le 0 ] && { echo "now"; return; }
+    d=$((delta / 86400))
+    h=$(((delta % 86400) / 3600))
+    m=$(((delta % 3600) / 60))
+    if [ "$d" -gt 0 ]; then echo "${d}d${h}h"
+    elif [ "$h" -gt 0 ]; then echo "${h}h${m}m"
+    else echo "${m}m"; fi
+}
+
+# Progress bar with its label inside: the text is the bar, and the color-coded
+# fill advances across it. Usage: build_text_bar "5h (42%)" 42
+build_text_bar() {
+    local text=" $1 " pct=$2 len filled fill_bg fill_fg blink=""
+    len=${#text}
+    filled=$((pct * len / 100))
+    [ "$filled" -gt "$len" ] && filled=$len
+    [ "$filled" -lt 0 ] && filled=0
+    if [ "$pct" -gt 89 ]; then fill_bg=$'\033[48;5;196m'; fill_fg=$'\033[97m'; blink=$BLINK
+    elif [ "$pct" -gt 79 ]; then fill_bg=$'\033[48;5;208m'; fill_fg=$'\033[30m'
+    elif [ "$pct" -gt 64 ]; then fill_bg=$'\033[48;5;220m'; fill_fg=$'\033[30m'
+    else fill_bg=$'\033[48;5;29m'; fill_fg=$'\033[97m'; fi
+    local empty_bg=$'\033[48;5;238m' empty_fg=$'\033[38;5;250m'
+    printf '%s' "${blink}${fill_bg}${fill_fg}${text:0:filled}${RESET}${empty_bg}${empty_fg}${text:filled}${RESET}"
+}
+
 # Color based on usage proximity to compaction threshold
 # Green < 50%, Yellow 50-75%, Red 75-100% of compaction threshold
 usage_color() {
@@ -38,7 +81,18 @@ usage_color() {
     fi
 }
 
-# Only show context info if we have valid data
+# Compose line 1 from the block template + context info
+compose_left() {
+    local info=$1
+    if [ "$context_limit" -gt 0 ]; then
+        printf '%s '"$color"'%s/%s'"$reset" "$info" "$used_fmt" "$compact_fmt"
+    else
+        printf '%s' "$info"
+    fi
+}
+
+strip_ansi() { sed $'s/\033\[[0-9;]*m//g'; }
+
 if [ "$context_limit" -gt 0 ]; then
     tokens_used=$((context_limit * used_pct / 100))
     compact_at=$((context_limit * compact_pct / 100))
@@ -46,7 +100,52 @@ if [ "$context_limit" -gt 0 ]; then
     compact_fmt=$(format_k "$compact_at")
     color=$(usage_color "$tokens_used" "$compact_at")
     reset='\033[0m'
-    printf '%s | '"$color"'%s/%s'"$reset" "$git_info" "$used_fmt" "$compact_fmt"
+fi
+
+# 5h session limit bar, slotted in after the model block (Pro/Max only)
+five_seg=""
+five_pct_raw=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+if [ -n "$five_pct_raw" ]; then
+    five_pct=$(printf '%.0f' "$five_pct_raw" 2>/dev/null)
+    five_seg=$(build_text_bar "5h (${five_pct}%)" "$five_pct")
+fi
+line_tpl=${line_tpl//@5H@/$five_seg}
+
+# Claude Code sets COLUMNS to the terminal width and renders the statusline
+# with ~2-col margins on each side, so keep content within COLUMNS - 4.
+width="${COLUMNS:-0}"
+[ "$width" -gt 0 ] 2>/dev/null || width=$(tput cols 2>/dev/null || echo 0)
+avail=$((width - 4))
+
+left=$(compose_left "${line_tpl//@TRUNC@/$trunc_val}")
+plain_left=$(printf '%s' "$left" | strip_ansi)
+plain_diff=$(printf '%s' "$diff_info" | strip_ansi)
+
+# Truncate the branch/path only when the line overflows the terminal.
+# Branches lose their tail (feature/very-long…); paths lose their head (…ub/dotfiles).
+if [ "$avail" -gt 0 ] && [ -n "$trunc_val" ]; then
+    total=${#plain_left}
+    [ -n "$diff_info" ] && total=$((total + 2 + ${#plain_diff}))
+    over=$((total - avail))
+    if [ "$over" -gt 0 ]; then
+        keep=$(( ${#trunc_val} - over - 1 ))
+        [ "$keep" -lt 6 ] && keep=6
+        if [ "$keep" -lt ${#trunc_val} ]; then
+            case $trunc_val in
+                /*) short="…${trunc_val:$(( ${#trunc_val} - keep ))}";;
+                *)  short="${trunc_val:0:$keep}…";;
+            esac
+            left=$(compose_left "${line_tpl//@TRUNC@/$short}")
+            plain_left=$(printf '%s' "$left" | strip_ansi)
+        fi
+    fi
+fi
+
+# Right-align diff stats at the end of the line
+if [ -n "$diff_info" ]; then
+    pad=$((avail - ${#plain_left} - ${#plain_diff}))
+    [ "$pad" -lt 2 ] && pad=2
+    printf '%s%*s%s' "$left" "$pad" '' "$diff_info"
 else
-    printf '%s' "$git_info"
+    printf '%s' "$left"
 fi

--- a/codex/.codex/agents/default.toml
+++ b/codex/.codex/agents/default.toml
@@ -1,2 +1,5 @@
+name = "default"
+description = "Default subagent role"
 model = "gpt-5.5"
 model_reasoning_effort = "medium"
+developer_instructions = "You are a focused subagent."

--- a/codex/.codex/config.toml
+++ b/codex/.codex/config.toml
@@ -26,8 +26,9 @@ max_depth = 2
 job_max_runtime_seconds = 7200
 
 [tui]
+show_tooltips = false
 notifications = true
-status_line = ["model-with-reasoning", "context-used", "git-branch", "pull-request-number", "branch-changes", "fast-mode"]
+status_line = ["model-with-reasoning", "context-used", "weekly-limit", "pull-request-number", "fast-mode", "approval-mode"]
 status_line_use_colors = true
 session_picker_view = "comfortable"
 terminal_title = ["activity", "app-name", "codex-version", "project-name"]
@@ -43,9 +44,6 @@ enabled = true
 [notice]
 fast_default_opt_out = true
 hide_rate_limit_model_nudge = true
-
-[plugins."sites@openai-bundled"]
-enabled = true
 
 [plugins."browser@openai-bundled"]
 enabled = true

--- a/gitconfig/.gitconfig
+++ b/gitconfig/.gitconfig
@@ -42,5 +42,8 @@
 [init]
 	defaultBranch = main
 
+[gpg "ssh"]
+	allowedSignersFile = ~/.config/git/allowed_signers
+
 [rerere]
 	enabled = true

--- a/gitconfig/.gitconfig-github
+++ b/gitconfig/.gitconfig-github
@@ -1,7 +1,7 @@
 [user]
 	email = 25832339+lvadla@users.noreply.github.com
 	name = Lance Vadla
-	signingkey = ~/.ssh/id_ed25519_sk.pub
+
 [gpg]
 	format = ssh
 

--- a/helix/.config/helix/config.toml
+++ b/helix/.config/helix/config.toml
@@ -1,3 +1,6 @@
+[editor]
+cursorline = true
+
 [editor.cursor-shape]
 insert = "bar"
 normal = "block"
@@ -5,3 +8,6 @@ select = "underline"
 
 [editor.file-picker]
 hidden = false
+
+[editor.inline-diagnostics]
+cursor-line = "hint"

--- a/helix/.config/helix/languages.toml
+++ b/helix/.config/helix/languages.toml
@@ -2,3 +2,8 @@
 name = "svelte"
 language-servers = [ "svelteserver", "tailwindcss-ls", "typescript-language-server" ]
 auto-format = true
+
+[[language]]
+name = "json"
+formatter = { command = "biome", args = ["format", "--stdin-file-path", "%{buffer_name}"] }
+auto-format = true

--- a/helix/.config/helix/languages.toml
+++ b/helix/.config/helix/languages.toml
@@ -1,0 +1,4 @@
+[[language]]
+name = "svelte"
+language-servers = [ "svelteserver", "tailwindcss-ls", "typescript-language-server" ]
+auto-format = true

--- a/helix/.stow-local-ignore
+++ b/helix/.stow-local-ignore
@@ -1,1 +1,0 @@
-README\.md

--- a/lazygit/.config/lazygit/config.yml
+++ b/lazygit/.config/lazygit/config.yml
@@ -26,7 +26,7 @@ gui:
   skipRewordInEditorWarning: false
   # Fraction of the total screen width to use for the left side section. You may want to pick a small number (e.g. 0.2) if you're using a narrow screen, so that you can see more of the main section.
   # Number from 0 to 1.0.
-  sidePanelWidth: 0.25
+  sidePanelWidth: 0.2
   # If true, increase the height of the focused side window; creating an accordion effect.
   expandFocusedSidePanel: true
   # The weight of the expanded side panel, relative to the other panels. 2 means
@@ -49,7 +49,7 @@ gui:
   # Possible values:
   # - 'left': split the window horizontally (side panel on the left, main view on the right)
   # - 'top': split the window vertically (side panel on top, main view below)
-  enlargedSideViewLocation: left
+  enlargedSideViewLocation: top
   # If true, wrap lines in the staging view to the width of the view. This
   # makes it much easier to work with diffs that have long lines, e.g.
   # paragraphs of markdown text.

--- a/lazygit/.config/lazygit/config.yml
+++ b/lazygit/.config/lazygit/config.yml
@@ -184,18 +184,16 @@ gui:
 # Config relating to git
 git:
   # See https://github.com/jesseduffield/lazygit/blob/master/docs/Custom_Pagers.md
-  pagers:
+  diffRenderers:
     - # Value of the --color arg in the git diff command. Some pagers want this to be set to 'always' and some want it set to 'never'
       colorArg: always
       # e.g.
       # diff-so-fancy
       # delta --dark --paging=never
       # ydiff -p cat -s --wrap --width={{columnWidth}}
-      pager: delta --paging=never --line-numbers --hyperlinks --hyperlinks-file-link-format="lazygit-edit://{path}:{line}"
+      command: delta --paging=never --line-numbers --hyperlinks --hyperlinks-file-link-format="lazygit-edit://{path}:{line}"
       # If true, Lazygit will use whatever pager is specified in `$GIT_PAGER`, `$PAGER`, or your *git config*. If the pager ends with something like ` | less` we will strip that part out, because less doesn't play nice with our rendering approach. If the custom pager uses less under the hood, that will also break rendering (hence the `--paging=never` flag for the `delta` pager).
       useConfig: false
-      # e.g. 'difft --color=always'
-      externalDiffCommand: ""
   # Config relating to committing
   commit:
     # If true, pass '--signoff' flag when committing

--- a/pi/.pi/agent/extensions/minimal-mode.ts
+++ b/pi/.pi/agent/extensions/minimal-mode.ts
@@ -1,0 +1,426 @@
+/**
+ * Minimal Mode Example - Demonstrates a "minimal" tool display mode
+ *
+ * This extension overrides built-in tools to provide custom rendering:
+ * - Collapsed mode: Only shows the tool call (command/path), no output
+ * - Expanded mode: Shows full output like the built-in renderers
+ *
+ * This demonstrates how a "minimal mode" could work, where ctrl+o cycles through:
+ * - Standard: Shows truncated output (current default)
+ * - Expanded: Shows full output (current expanded)
+ * - Minimal: Shows only tool call, no output (this extension's collapsed mode)
+ *
+ * Usage:
+ *   pi -e ./minimal-mode.ts
+ *
+ * Then use ctrl+o to toggle between minimal (collapsed) and full (expanded) views.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+	createBashTool,
+	createEditTool,
+	createFindTool,
+	createGrepTool,
+	createLsTool,
+	createReadTool,
+	createWriteTool,
+} from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { homedir } from "os";
+
+/**
+ * Shorten a path by replacing home directory with ~
+ */
+function shortenPath(path: string): string {
+	const home = homedir();
+	if (path.startsWith(home)) {
+		return `~${path.slice(home.length)}`;
+	}
+	return path;
+}
+
+// Cache for built-in tools by cwd
+const toolCache = new Map<string, ReturnType<typeof createBuiltInTools>>();
+
+function createBuiltInTools(cwd: string) {
+	return {
+		read: createReadTool(cwd),
+		bash: createBashTool(cwd),
+		edit: createEditTool(cwd),
+		write: createWriteTool(cwd),
+		find: createFindTool(cwd),
+		grep: createGrepTool(cwd),
+		ls: createLsTool(cwd),
+	};
+}
+
+function getBuiltInTools(cwd: string) {
+	let tools = toolCache.get(cwd);
+	if (!tools) {
+		tools = createBuiltInTools(cwd);
+		toolCache.set(cwd, tools);
+	}
+	return tools;
+}
+
+export default function (pi: ExtensionAPI) {
+	// =========================================================================
+	// Read Tool
+	// =========================================================================
+	pi.registerTool({
+		name: "read",
+		label: "read",
+		description:
+			"Read the contents of a file. Supports text files and images (jpg, png, gif, webp). Images are sent as attachments. For text files, output is truncated to 2000 lines or 50KB (whichever is hit first). Use offset/limit for large files.",
+		parameters: getBuiltInTools(process.cwd()).read.parameters,
+
+		async execute(toolCallId, params, signal, onUpdate, ctx) {
+			const tools = getBuiltInTools(ctx.cwd);
+			return tools.read.execute(toolCallId, params, signal, onUpdate);
+		},
+
+		renderCall(args, theme, _context) {
+			const path = shortenPath(args.path || "");
+			let pathDisplay = path ? theme.fg("accent", path) : theme.fg("toolOutput", "...");
+
+			// Show line range if specified
+			if (args.offset !== undefined || args.limit !== undefined) {
+				const startLine = args.offset ?? 1;
+				const endLine = args.limit !== undefined ? startLine + args.limit - 1 : "";
+				pathDisplay += theme.fg("warning", `:${startLine}${endLine ? `-${endLine}` : ""}`);
+			}
+
+			return new Text(`${theme.fg("toolTitle", theme.bold("read"))} ${pathDisplay}`, 0, 0);
+		},
+
+		renderResult(result, { expanded }, theme, _context) {
+			// Minimal mode: show nothing in collapsed state
+			if (!expanded) {
+				return new Text("", 0, 0);
+			}
+
+			// Expanded mode: show full output
+			const textContent = result.content.find((c) => c.type === "text");
+			if (!textContent || textContent.type !== "text") {
+				return new Text("", 0, 0);
+			}
+
+			const lines = textContent.text.split("\n");
+			const output = lines.map((line) => theme.fg("toolOutput", line)).join("\n");
+			return new Text(`\n${output}`, 0, 0);
+		},
+	});
+
+	// =========================================================================
+	// Bash Tool
+	// =========================================================================
+	pi.registerTool({
+		name: "bash",
+		label: "bash",
+		description:
+			"Execute a bash command in the current working directory. Returns stdout and stderr. Output is truncated to last 2000 lines or 50KB (whichever is hit first).",
+		parameters: getBuiltInTools(process.cwd()).bash.parameters,
+
+		async execute(toolCallId, params, signal, onUpdate, ctx) {
+			const tools = getBuiltInTools(ctx.cwd);
+			return tools.bash.execute(toolCallId, params, signal, onUpdate);
+		},
+
+		renderCall(args, theme, _context) {
+			const command = args.command || "...";
+			const timeout = args.timeout as number | undefined;
+			const timeoutSuffix = timeout ? theme.fg("muted", ` (timeout ${timeout}s)`) : "";
+
+			return new Text(theme.fg("toolTitle", theme.bold(`$ ${command}`)) + timeoutSuffix, 0, 0);
+		},
+
+		renderResult(result, { expanded }, theme, _context) {
+			// Minimal mode: show nothing in collapsed state
+			if (!expanded) {
+				return new Text("", 0, 0);
+			}
+
+			// Expanded mode: show full output
+			const textContent = result.content.find((c) => c.type === "text");
+			if (!textContent || textContent.type !== "text") {
+				return new Text("", 0, 0);
+			}
+
+			const output = textContent.text
+				.trim()
+				.split("\n")
+				.map((line) => theme.fg("toolOutput", line))
+				.join("\n");
+
+			if (!output) {
+				return new Text("", 0, 0);
+			}
+
+			return new Text(`\n${output}`, 0, 0);
+		},
+	});
+
+	// =========================================================================
+	// Write Tool
+	// =========================================================================
+	pi.registerTool({
+		name: "write",
+		label: "write",
+		description:
+			"Write content to a file. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories.",
+		parameters: getBuiltInTools(process.cwd()).write.parameters,
+
+		async execute(toolCallId, params, signal, onUpdate, ctx) {
+			const tools = getBuiltInTools(ctx.cwd);
+			return tools.write.execute(toolCallId, params, signal, onUpdate);
+		},
+
+		renderCall(args, theme, _context) {
+			const path = shortenPath(args.path || "");
+			const pathDisplay = path ? theme.fg("accent", path) : theme.fg("toolOutput", "...");
+			const lineCount = args.content ? args.content.split("\n").length : 0;
+			const lineInfo = lineCount > 0 ? theme.fg("muted", ` (${lineCount} lines)`) : "";
+
+			return new Text(`${theme.fg("toolTitle", theme.bold("write"))} ${pathDisplay}${lineInfo}`, 0, 0);
+		},
+
+		renderResult(result, { expanded }, theme, _context) {
+			// Minimal mode: show nothing (file was written)
+			if (!expanded) {
+				return new Text("", 0, 0);
+			}
+
+			// Expanded mode: show error if any
+			if (result.content.some((c) => c.type === "text" && c.text)) {
+				const textContent = result.content.find((c) => c.type === "text");
+				if (textContent?.type === "text" && textContent.text) {
+					return new Text(`\n${theme.fg("error", textContent.text)}`, 0, 0);
+				}
+			}
+
+			return new Text("", 0, 0);
+		},
+	});
+
+	// =========================================================================
+	// Edit Tool
+	// =========================================================================
+	pi.registerTool({
+		name: "edit",
+		label: "edit",
+		description:
+			"Edit a file by replacing exact text. The oldText must match exactly (including whitespace). Use this for precise, surgical edits.",
+		parameters: getBuiltInTools(process.cwd()).edit.parameters,
+
+		async execute(toolCallId, params, signal, onUpdate, ctx) {
+			const tools = getBuiltInTools(ctx.cwd);
+			return tools.edit.execute(toolCallId, params, signal, onUpdate);
+		},
+
+		renderCall(args, theme, _context) {
+			const path = shortenPath(args.path || "");
+			const pathDisplay = path ? theme.fg("accent", path) : theme.fg("toolOutput", "...");
+
+			return new Text(`${theme.fg("toolTitle", theme.bold("edit"))} ${pathDisplay}`, 0, 0);
+		},
+
+		renderResult(result, { expanded }, theme, _context) {
+			// Minimal mode: show nothing in collapsed state
+			if (!expanded) {
+				return new Text("", 0, 0);
+			}
+
+			// Expanded mode: show diff or error
+			const textContent = result.content.find((c) => c.type === "text");
+			if (!textContent || textContent.type !== "text") {
+				return new Text("", 0, 0);
+			}
+
+			// For errors, show the error message
+			const text = textContent.text;
+			if (text.includes("Error") || text.includes("error")) {
+				return new Text(`\n${theme.fg("error", text)}`, 0, 0);
+			}
+
+			// Otherwise show the text (would be nice to show actual diff here)
+			return new Text(`\n${theme.fg("toolOutput", text)}`, 0, 0);
+		},
+	});
+
+	// =========================================================================
+	// Find Tool
+	// =========================================================================
+	pi.registerTool({
+		name: "find",
+		label: "find",
+		description:
+			"Find files by name pattern (glob). Searches recursively from the specified path. Output limited to 200 results.",
+		parameters: getBuiltInTools(process.cwd()).find.parameters,
+
+		async execute(toolCallId, params, signal, onUpdate, ctx) {
+			const tools = getBuiltInTools(ctx.cwd);
+			return tools.find.execute(toolCallId, params, signal, onUpdate);
+		},
+
+		renderCall(args, theme, _context) {
+			const pattern = args.pattern || "";
+			const path = shortenPath(args.path || ".");
+			const limit = args.limit;
+
+			let text = `${theme.fg("toolTitle", theme.bold("find"))} ${theme.fg("accent", pattern)}`;
+			text += theme.fg("toolOutput", ` in ${path}`);
+			if (limit !== undefined) {
+				text += theme.fg("toolOutput", ` (limit ${limit})`);
+			}
+
+			return new Text(text, 0, 0);
+		},
+
+		renderResult(result, { expanded }, theme, _context) {
+			if (!expanded) {
+				// Minimal: just show count
+				const textContent = result.content.find((c) => c.type === "text");
+				if (textContent?.type === "text") {
+					const count = textContent.text.trim().split("\n").filter(Boolean).length;
+					if (count > 0) {
+						return new Text(theme.fg("muted", ` → ${count} files`), 0, 0);
+					}
+				}
+				return new Text("", 0, 0);
+			}
+
+			// Expanded: show full results
+			const textContent = result.content.find((c) => c.type === "text");
+			if (!textContent || textContent.type !== "text") {
+				return new Text("", 0, 0);
+			}
+
+			const output = textContent.text
+				.trim()
+				.split("\n")
+				.map((line) => theme.fg("toolOutput", line))
+				.join("\n");
+
+			return new Text(`\n${output}`, 0, 0);
+		},
+	});
+
+	// =========================================================================
+	// Grep Tool
+	// =========================================================================
+	pi.registerTool({
+		name: "grep",
+		label: "grep",
+		description:
+			"Search file contents by regex pattern. Uses ripgrep for fast searching. Output limited to 200 matches.",
+		parameters: getBuiltInTools(process.cwd()).grep.parameters,
+
+		async execute(toolCallId, params, signal, onUpdate, ctx) {
+			const tools = getBuiltInTools(ctx.cwd);
+			return tools.grep.execute(toolCallId, params, signal, onUpdate);
+		},
+
+		renderCall(args, theme, _context) {
+			const pattern = args.pattern || "";
+			const path = shortenPath(args.path || ".");
+			const glob = args.glob;
+			const limit = args.limit;
+
+			let text = `${theme.fg("toolTitle", theme.bold("grep"))} ${theme.fg("accent", `/${pattern}/`)}`;
+			text += theme.fg("toolOutput", ` in ${path}`);
+			if (glob) {
+				text += theme.fg("toolOutput", ` (${glob})`);
+			}
+			if (limit !== undefined) {
+				text += theme.fg("toolOutput", ` limit ${limit}`);
+			}
+
+			return new Text(text, 0, 0);
+		},
+
+		renderResult(result, { expanded }, theme, _context) {
+			if (!expanded) {
+				// Minimal: just show match count
+				const textContent = result.content.find((c) => c.type === "text");
+				if (textContent?.type === "text") {
+					const count = textContent.text.trim().split("\n").filter(Boolean).length;
+					if (count > 0) {
+						return new Text(theme.fg("muted", ` → ${count} matches`), 0, 0);
+					}
+				}
+				return new Text("", 0, 0);
+			}
+
+			// Expanded: show full results
+			const textContent = result.content.find((c) => c.type === "text");
+			if (!textContent || textContent.type !== "text") {
+				return new Text("", 0, 0);
+			}
+
+			const output = textContent.text
+				.trim()
+				.split("\n")
+				.map((line) => theme.fg("toolOutput", line))
+				.join("\n");
+
+			return new Text(`\n${output}`, 0, 0);
+		},
+	});
+
+	// =========================================================================
+	// Ls Tool
+	// =========================================================================
+	pi.registerTool({
+		name: "ls",
+		label: "ls",
+		description:
+			"List directory contents with file sizes. Shows files and directories with their sizes. Output limited to 500 entries.",
+		parameters: getBuiltInTools(process.cwd()).ls.parameters,
+
+		async execute(toolCallId, params, signal, onUpdate, ctx) {
+			const tools = getBuiltInTools(ctx.cwd);
+			return tools.ls.execute(toolCallId, params, signal, onUpdate);
+		},
+
+		renderCall(args, theme, _context) {
+			const path = shortenPath(args.path || ".");
+			const limit = args.limit;
+
+			let text = `${theme.fg("toolTitle", theme.bold("ls"))} ${theme.fg("accent", path)}`;
+			if (limit !== undefined) {
+				text += theme.fg("toolOutput", ` (limit ${limit})`);
+			}
+
+			return new Text(text, 0, 0);
+		},
+
+		renderResult(result, { expanded }, theme, _context) {
+			if (!expanded) {
+				// Minimal: just show entry count
+				const textContent = result.content.find((c) => c.type === "text");
+				if (textContent?.type === "text") {
+					const count = textContent.text.trim().split("\n").filter(Boolean).length;
+					if (count > 0) {
+						return new Text(theme.fg("muted", ` → ${count} entries`), 0, 0);
+					}
+				}
+				return new Text("", 0, 0);
+			}
+
+			// Expanded: show full listing
+			const textContent = result.content.find((c) => c.type === "text");
+			if (!textContent || textContent.type !== "text") {
+				return new Text("", 0, 0);
+			}
+
+			const output = textContent.text
+				.trim()
+				.split("\n")
+				.map((line) => theme.fg("toolOutput", line))
+				.join("\n");
+
+			return new Text(`\n${output}`, 0, 0);
+		},
+	});
+}

--- a/pi/.pi/agent/extensions/update.ts
+++ b/pi/.pi/agent/extensions/update.ts
@@ -1,0 +1,155 @@
+import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { VERSION, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const PATCH_SCRIPT = `${process.env.HOME}/.pi/scripts/apply-patches.sh`;
+const SETTINGS_FILE = `${process.env.HOME}/.pi/agent/settings.json`;
+const UNKNOWN_VERSION = "unknown";
+const NPM_PREFIX = "npm:";
+const PI_PACKAGE = "@earendil-works/pi-coding-agent";
+const UPDATE_COMMAND = "update";
+const UI = {
+  commandDescription: "Update pi and all installed extensions, apply local patches, and restart",
+  noUpdates: "No updates available.",
+  updating: "Updating pi and installed extensions...",
+  noPatches: "Applying patches:\nNo patches were applied.",
+  restarting: "Updated pi and extensions. Restarting...",
+  settingsError: "Extensions: unable to read settings",
+};
+
+function updateFailure(code: number, details: string): string {
+  return `Update failed (exit ${code}): ${details}`;
+}
+
+function patchFailure(details: string): string {
+  return `Update succeeded, but applying local patches failed: ${details}`;
+}
+
+type PackageSpec = string | { source?: string };
+
+type VersionInfo = {
+  name: string;
+  current: string;
+  target: string;
+};
+
+function npmPackageName(spec: string): string | null {
+  if (!spec.startsWith(NPM_PREFIX)) return null;
+  const raw = spec.slice(NPM_PREFIX.length);
+  const versionSeparator = raw.startsWith("@") ? raw.indexOf("@", 1) : raw.indexOf("@");
+  const name = versionSeparator === -1 ? raw : raw.slice(0, versionSeparator);
+  return name || null;
+}
+
+async function latestNpmVersion(name: string): Promise<string | undefined> {
+  try {
+    const response = await fetch(`https://registry.npmjs.org/${name}`, {
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) return undefined;
+    const data = (await response.json()) as { [key: string]: unknown };
+    return typeof data["dist-tags"] === "object" && data["dist-tags"] !== null
+      ? ((data["dist-tags"] as { latest?: unknown }).latest as string | undefined)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function getVersionInfo(name: string): Promise<VersionInfo> {
+  const packageFile = `${process.env.HOME}/.pi/agent/npm/node_modules/${name}/package.json`;
+  let current = UNKNOWN_VERSION;
+  try {
+    const packageJson = JSON.parse(await readFile(packageFile, "utf8")) as { version?: string };
+    current = packageJson.version ?? current;
+  } catch {
+    // The update command will report the real install error if the package is unavailable.
+  }
+
+  return { name, current, target: (await latestNpmVersion(name)) ?? UNKNOWN_VERSION };
+}
+
+async function getUpdateSummary(): Promise<{ lines: string[]; hasUpdates: boolean; complete: boolean }> {
+  let settings: { packages?: PackageSpec[] };
+  try {
+    settings = JSON.parse(await readFile(SETTINGS_FILE, "utf8")) as { packages?: PackageSpec[] };
+  } catch {
+    return {
+      lines: [`Pi: v${VERSION} → ${UNKNOWN_VERSION}`, UI.settingsError],
+      hasUpdates: true,
+      complete: false,
+    };
+  }
+
+  const names = (settings.packages ?? [])
+    .map((item) => (typeof item === "string" ? item : item.source))
+    .filter((source): source is string => source !== undefined)
+    .map(npmPackageName)
+    .filter((name): name is string => name !== null);
+  const packages = await Promise.all([...new Set(names)].map(getVersionInfo));
+
+  const piTarget = (await latestNpmVersion(PI_PACKAGE)) ?? UNKNOWN_VERSION;
+  const formatVersionLine = (name: string, current: string, target: string): string =>
+    current === target && target !== "unknown"
+      ? `${name}: v${current} (latest)`
+      : `${name}: v${current} → v${target}`;
+  const lines = [
+    formatVersionLine("Pi", VERSION, piTarget),
+    ...packages.map((item) => formatVersionLine(item.name, item.current, item.target)),
+  ];
+  const versions = [
+    { current: VERSION, target: piTarget },
+    ...packages,
+  ];
+
+  return {
+    lines,
+    hasUpdates: versions.some((item) => item.target !== UNKNOWN_VERSION && item.current !== item.target),
+    complete: versions.every((item) => item.current !== UNKNOWN_VERSION && item.target !== UNKNOWN_VERSION),
+  }; 
+}
+
+export default function (pi: ExtensionAPI) {
+  let pendingRestart = false;
+
+  process.on("exit", () => {
+    if (!pendingRestart) return;
+    spawnSync(process.execPath, process.argv.slice(1), { stdio: "inherit" });
+  });
+
+  pi.registerCommand(UPDATE_COMMAND, {
+    description: UI.commandDescription,
+    handler: async (_args, ctx) => {
+      const summary = await getUpdateSummary();
+      if (summary.complete && !summary.hasUpdates) {
+        ctx.ui.notify(
+          `${summary.lines.join("\n")}\n\n${UI.noUpdates}`,
+          "info",
+        );
+        return;
+      }
+      ctx.ui.notify(UI.updating, "info");
+
+      const update = await pi.exec("pi", ["update", "--all"], { timeout: 120_000 });
+      if (update.code !== 0) {
+        ctx.ui.notify(updateFailure(update.code, (update.stderr || update.stdout || "").trim().slice(0, 300)), "error");
+        return;
+      }
+
+      const patch = await pi.exec(PATCH_SCRIPT, [], { timeout: 30_000 });
+      if (patch.code !== 0) {
+        ctx.ui.notify(patchFailure((patch.stderr || patch.stdout || "").trim().slice(0, 300)), "error");
+        return;
+      }
+      const patchStatus = patch.stdout.trim()
+        ? `Applying patches:\n${patch.stdout.trim()}`
+        : UI.noPatches;
+      ctx.ui.notify(
+        `${summary.lines.join("\n")}\n\n${patchStatus}\n\n${UI.restarting}`,
+        "info",
+      );
+      pendingRestart = true;
+      ctx.shutdown();
+    },
+  });
+}

--- a/pi/.pi/agent/models.json
+++ b/pi/.pi/agent/models.json
@@ -1,0 +1,11 @@
+{
+	"providers": {
+		"openai-codex": {
+			"modelOverrides": {
+				"gpt-5.6-luna": { "contextWindow": 272000 },
+				"gpt-5.6-sol": { "contextWindow": 272000 },
+				"gpt-5.6-terra": { "contextWindow": 272000 }
+			}
+		},
+	}
+}

--- a/pi/.pi/agent/settings.json
+++ b/pi/.pi/agent/settings.json
@@ -1,22 +1,27 @@
 {
-	"editorPaddingX": 1,
-	"hideThinkingBlock": true,
-	"collapseChangelog": false,
-	"quietStartup": false,
-	"enableInstallTelemetry": false,
-	"defaultThinkingLevel": "high",
-	"theme": "dark",
-	"terminal": { "showImages": false },
-	"autocompleteMaxVisible": 7,
-	"defaultProvider": "openai-codex",
-	"defaultModel": "gpt-5.6-luna",
-	"enabledModels": [
-		"gpt-5.6-luna",
-		"gpt-5.6-terra",
-		"gpt-5.6-sol",
-	],
-	"treeFilterMode": "no-tools",
-	"showCacheMissNotices": true,
-	"transport": "auto",
-	"packages": ["npm:@ff-labs/pi-fff", "npm:pi-web-access"]
+  "editorPaddingX": 1,
+  "hideThinkingBlock": true,
+  "collapseChangelog": false,
+  "quietStartup": false,
+  "enableInstallTelemetry": false,
+  "defaultThinkingLevel": "high",
+  "theme": "dark",
+  "terminal": {
+    "showImages": false
+  },
+  "autocompleteMaxVisible": 7,
+  "defaultProvider": "openai-codex",
+  "defaultModel": "gpt-5.6-terra",
+  "enabledModels": [
+    "gpt-5.6-luna",
+    "gpt-5.6-terra",
+    "gpt-5.6-sol",
+  ],
+  "treeFilterMode": "no-tools",
+  "showCacheMissNotices": true,
+  "transport": "auto",
+  "packages": [
+    "npm:@ff-labs/pi-fff",
+    "npm:pi-web-access"
+  ],
 }

--- a/pi/.pi/agent/settings.json
+++ b/pi/.pi/agent/settings.json
@@ -1,0 +1,22 @@
+{
+	"editorPaddingX": 1,
+	"hideThinkingBlock": true,
+	"collapseChangelog": false,
+	"quietStartup": false,
+	"enableInstallTelemetry": false,
+	"defaultThinkingLevel": "high",
+	"theme": "dark",
+	"terminal": { "showImages": false },
+	"autocompleteMaxVisible": 7,
+	"defaultProvider": "openai-codex",
+	"defaultModel": "gpt-5.6-luna",
+	"enabledModels": [
+		"gpt-5.6-luna",
+		"gpt-5.6-terra",
+		"gpt-5.6-sol",
+	],
+	"treeFilterMode": "no-tools",
+	"showCacheMissNotices": true,
+	"transport": "auto",
+	"packages": ["npm:@ff-labs/pi-fff", "npm:pi-web-access"]
+}

--- a/pi/.pi/patches/@ff-labs/pi-fff/max-5-lines.patch
+++ b/pi/.pi/patches/@ff-labs/pi-fff/max-5-lines.patch
@@ -1,0 +1,29 @@
+--- src/index.ts
++++ src/index.ts
+@@ -783,7 +783,7 @@
+     },
+ 
+     renderResult(result, options, theme, context) {
+-      return renderTextResult(result, options, theme, context, 15);
++      return renderTextResult(result, options, theme, context, 5);
+     },
+   });
+ 
+@@ -933,7 +933,7 @@
+     },
+ 
+     renderResult(result, options, theme, context) {
+-      return renderTextResult(result, options, theme, context, 20);
++      return renderTextResult(result, options, theme, context, 5);
+     },
+   });
+ 
+@@ -1033,7 +1033,7 @@
+       },
+ 
+       renderResult(result, options, theme, context) {
+-        return renderTextResult(result, options, theme, context, 15);
++        return renderTextResult(result, options, theme, context, 5);
+       },
+     });
+   } // end if (enableMultiGrep)

--- a/pi/.pi/scripts/apply-patches.sh
+++ b/pi/.pi/scripts/apply-patches.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+patch_root="$HOME/.pi/patches"
+package_root="$HOME/.pi/agent/npm/node_modules"
+
+if [[ ! -d "$patch_root" ]]; then
+  exit 0
+fi
+
+while IFS= read -r patch_file; do
+  relative_file="${patch_file#"$patch_root/"}"
+  target="${relative_file%%/*}"
+  target="${target}/${relative_file#*/}"
+  target="${target%/*}"
+  package_dir="$package_root/$target"
+
+  if [[ ! -d "$package_dir" ]]; then
+    echo "Patch target is missing for $relative_file: $package_dir" >&2
+    exit 1
+  fi
+
+  if (cd "$package_dir" && patch --dry-run -p0 < "$patch_file" >/dev/null 2>&1); then
+    echo "Applying $relative_file"
+    (cd "$package_dir" && patch -p0 < "$patch_file" >/dev/null)
+    continue
+  fi
+
+  if (cd "$package_dir" && patch --dry-run -R -p0 < "$patch_file" >/dev/null 2>&1); then
+    continue
+  fi
+
+  echo "Patch does not match the installed package: $relative_file" >&2
+  exit 1
+done < <(find "$patch_root" -type f -name '*.patch' -print | sort)

--- a/zed/.config/zed/settings.json
+++ b/zed/.config/zed/settings.json
@@ -1,5 +1,5 @@
 {
-	"diff_view_style": "unified",
+	"diff_view_style": "split",
 	"agent_servers": {
 		"cursor": {
 			"favorite_config_option_values": {
@@ -14,6 +14,7 @@
 	"helix_mode": true,
 	"vim_mode": true,
 	"agent": {
+		"flexible": true,
 		"dock": "left",
 		"show_turn_stats": true,
 		"message_editor_min_lines": 3,
@@ -65,7 +66,8 @@
 		},
 	},
 	"git_panel": {
-		"default_width": 400,
+		"tree_view": true,
+		"default_width": 600,
 		"dock": "left",
 	},
 	"hard_tabs": true,

--- a/zed/.config/zed/settings.json
+++ b/zed/.config/zed/settings.json
@@ -1,4 +1,5 @@
 {
+	"minimum_split_diff_width": 110.0,
 	"diff_view_style": "split",
 	"word_diff_enabled": true,
 	"when_closing_with_no_tabs": "keep_window_open",
@@ -12,7 +13,6 @@
 		"message_editor_min_lines": 3,
 		"use_modifier_to_send": true,
 		"expand_terminal_card": false,
-		"enable_feedback": false,
 		"default_profile": "ask",
 		"default_width": 400,
 		"play_sound_when_agent_done": "when_hidden",
@@ -53,8 +53,9 @@
 		"git_gutter": "tracked_files",
 		"hunk_style": "unstaged_hollow",
 		"inline_blame": {
-			"enabled": false,
-			"show_commit_summary": false,
+			"enabled": true,
+			"show_commit_summary": true,
+			"location": "status_bar",
 		},
 	},
 	"git_panel": {
@@ -145,6 +146,6 @@
 		"light": "GitHub Light",
 		"mode": "system",
 	},
-	"unnecessary_code_fade": 0.7,
+	"unnecessary_code_fade": 0.5,
 	"wrap_guides": [80],
 }

--- a/zed/.config/zed/settings.json
+++ b/zed/.config/zed/settings.json
@@ -146,6 +146,10 @@
 		"light": "GitHub Light",
 		"mode": "system",
 	},
+	"theme_overrides": {
+		"GitHub Dark Dimmed": { "elevated_surface.background": "#2d333b" },
+		"GitHub Light": { "elevated_surface.background": "#f6f8fa" },
+	},
 	"unnecessary_code_fade": 0.5,
 	"wrap_guides": [80],
 }

--- a/zed/.config/zed/settings.json
+++ b/zed/.config/zed/settings.json
@@ -1,13 +1,5 @@
 {
 	"diff_view_style": "split",
-	"agent_servers": {
-		"cursor": {
-			"favorite_config_option_values": {
-				"model": ["composer-2.5[fast=true]"],
-			},
-			"type": "registry",
-		},
-	},
 	"word_diff_enabled": true,
 	"when_closing_with_no_tabs": "keep_window_open",
 	"redact_private_values": true,

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -17,7 +17,7 @@ eval "$(pyenv init - --no-rehash)"
 eval "$(starship init zsh)"
 
 HOMEBREW_NO_INSTALL_UPGRADE=1
-HISTORY_IGNORE="(ls|pwd|exit)*"
+HISTORY_IGNORE="(cd|ls|pwd|exit)*"
 HISTFILE=$HOME/.zsh_history
 HISTSIZE=1000000
 SAVEHIST=1000000


### PR DESCRIPTION
## August 2026 release

Mostly focuses on coding agents this month. Git signing was also restructured so it stops breaking mid-rebase.

### Coding agents
- adds an `/update` pi extension that checks for updates to Pi and installed extensions, applies checked-in local patches, and restarts. Includes the `minimal-mode` extension, model context-window overrides, and an FFF minimal-mode patch.
- claude statusline reworked into colored blocks. Diff stats now count staged and unstaged changes instead of commits only. Also adds a usage limit bar.
- codex statusline improved, tooltips off, unused plugins dropped, and a simple default subagent configuration added.

### Editor
- dynamic split diffs in zed, git panel switched to tree view, inline blame back on in the status bar, and theme overrides.
- started tracking `helix/languages.toml` with Svelte language servers and auto-formatting, plus Biome formatting for JSON.

### Window management
- removed the `alt - p` padding toggles
- Ghostty floating windows now use a fixed size and are centered
- let the OS position the Firefox picture-in-picture window instead of forcing a grid

### Version control
- removed the machine-specific signing key from the tracked GitHub config and configured a local `allowed_signers` file so signatures verify.
- adjust lazygit side panel and enable a stacked view on the `+` key.

### Shell
- added `cd` to the ignored command patterns for zsh history.
